### PR TITLE
bugfix_01_upgrade-markupsafe

### DIFF
--- a/API/requirements/base.txt
+++ b/API/requirements/base.txt
@@ -9,7 +9,7 @@ aniso8601==3.0.0
 click==6.7
 itsdangerous==0.24
 Jinja2==2.11
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 python-dotenv==0.8.2
 pytz==2018.4
 six==1.11.0


### PR DESCRIPTION
Upgraded MarkupSafe ro version 1.1.1 due a error caused by incompatibility with a more recent version of setuptools